### PR TITLE
Update to bfmarc.md

### DIFF
--- a/model/bfmarc.md
+++ b/model/bfmarc.md
@@ -2138,7 +2138,7 @@ NEEDS FURTHER DISCUSSION G SAYS KEEP V SAYS REMOVE
 * synonyms: 
 * scope: <http://bibfra.me/vocab/marc>
 
-## titleStatement
+## statementOfResponsibility
 * label: statement of responsibility
 * description: Transcribed information from the resource identifying the names and possibly functions of Agents responsible for or contributing to the creation of the intellectual or artistic content of the resource. 
 * value: Literal


### PR DESCRIPTION
Changed ## titleStatement to ## statementOfResponsibility. Eric previously updated the label to statement of responsibility. This change is per BF Lite Core Team mapping to PCC Core Terms (bf:statementOfResponsibility is mapped to rdam:statmentOfResponsibilityRelatingtoTitleProper).
